### PR TITLE
More compass changes

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -149,6 +149,17 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     // flag exiting this function
     in_arm_motors = false;
 
+    Location loc;
+    ahrs.get_location(loc);
+    if(loc.is_zero()) {
+      if(!sub.g2.backup_home_lat && !sub.g2.backup_home_lon) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "No position available.");
+        gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded.");
+      } else {
+        gcs().send_text(MAV_SEVERITY_INFO, "Using backup location.");
+        sub.set_origin(Location(sub.g2.backup_home_lat, sub.g2.backup_home_lon, 0, Location::AltFrame::ABSOLUTE));
+      }
+    }
     // return success
     return true;
 }

--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -149,17 +149,11 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
     // flag exiting this function
     in_arm_motors = false;
 
-    Location loc;
-    ahrs.get_location(loc);
-    if(loc.is_zero()) {
-      if(!sub.g2.backup_home_lat && !sub.g2.backup_home_lon) {
-        gcs().send_text(MAV_SEVERITY_WARNING, "No position available.");
-        gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded.");
-      } else {
-        gcs().send_text(MAV_SEVERITY_INFO, "Using backup location.");
-        sub.set_origin(Location(sub.g2.backup_home_lat, sub.g2.backup_home_lon, 0, Location::AltFrame::ABSOLUTE));
-      }
+    // if we do not have an ekf origin then we can't use the WMM tables
+    if (!sub.ensure_ekf_origin()) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Compass performance degraded");
     }
+
     // return success
     return true;
 }

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -377,4 +377,23 @@ void Sub::stats_update(void)
 }
 #endif
 
+
+void Sub::set_origin(const Location& loc)
+{
+// check location is valid
+    if (!loc.check_latlng()) {
+        return;
+    }
+    // check if EKF origin has already been set
+    Location ekf_origin;
+    if (ahrs.get_origin(ekf_origin)) {
+        return;
+    }
+
+    if (!ahrs.set_origin(loc)) {
+        return;
+    }
+
+}
+
 AP_HAL_MAIN_CALLBACKS(&sub);

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -391,8 +391,8 @@ bool Sub::ensure_ekf_origin()
         return false;
     }
 
-    auto backup_origin = Location(static_cast<int32_t>(sub.g2.backup_home_lat * 1e7),
-                                  static_cast<int32_t>(sub.g2.backup_home_lon * 1e7), 0, Location::AltFrame::ABSOLUTE);
+    auto backup_origin = Location(static_cast<int32_t>(sub.g2.backup_origin_lat * 1e7),
+                                  static_cast<int32_t>(sub.g2.backup_origin_lon * 1e7), 0, Location::AltFrame::ABSOLUTE);
 
     if (backup_origin.lat == 0 || backup_origin.lng == 0) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Backup location parameters are missing or zero");

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -377,23 +377,49 @@ void Sub::stats_update(void)
 }
 #endif
 
-
-void Sub::set_origin(const Location& loc)
+bool Sub::ensure_ekf_origin()
 {
-// check location is valid
-    if (!loc.check_latlng()) {
-        return;
-    }
-    // check if EKF origin has already been set
     Location ekf_origin;
     if (ahrs.get_origin(ekf_origin)) {
-        return;
+        // ekf origin is set
+        return true;
     }
 
-    if (!ahrs.set_origin(loc)) {
-        return;
+    if (gps.num_sensors() > 0) {
+        // wait for the gps sensor to set the origin
+        // alert the pilot to poor compass performance
+        return false;
     }
 
+    auto backup_origin = Location(static_cast<int32_t>(sub.g2.backup_home_lat * 1e7),
+                                  static_cast<int32_t>(sub.g2.backup_home_lon * 1e7), 0, Location::AltFrame::ABSOLUTE);
+
+    if (backup_origin.lat == 0 || backup_origin.lng == 0) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Backup location parameters are missing or zero");
+        return false;
+    }
+
+    if (!check_latlng(backup_origin.lat, backup_origin.lng)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Backup location parameters are not valid");
+        return false;
+    }
+
+    if (!ahrs.set_origin(backup_origin)) {
+        // a possible problem is that ek3_srcn_posxy is set to 3 (gps)
+        gcs().send_text(MAV_SEVERITY_WARNING, "Failed to set origin, check EK3_SRC parameters");
+        return false;
+    }
+
+    gcs().send_text(MAV_SEVERITY_INFO, "Using backup location");
+
+#if HAL_LOGGING_ENABLED
+    ahrs.Log_Write_Home_And_Origin();
+#endif
+
+    // send ekf origin to GCS
+    gcs().send_message(MSG_ORIGIN);
+
+    return true;
 }
 
 AP_HAL_MAIN_CALLBACKS(&sub);

--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -392,7 +392,9 @@ bool Sub::ensure_ekf_origin()
     }
 
     auto backup_origin = Location(static_cast<int32_t>(sub.g2.backup_origin_lat * 1e7),
-                                  static_cast<int32_t>(sub.g2.backup_origin_lon * 1e7), 0, Location::AltFrame::ABSOLUTE);
+                                  static_cast<int32_t>(sub.g2.backup_origin_lon * 1e7),
+                                  static_cast<int32_t>(sub.g2.backup_origin_alt * 100),
+                                  Location::AltFrame::ABSOLUTE);
 
     if (backup_origin.lat == 0 || backup_origin.lng == 0) {
         gcs().send_text(MAV_SEVERITY_WARNING, "Backup location parameters are missing or zero");

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -709,7 +709,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // 18 was scripting
 
-    // 19 was airspeed
+    // @Param: HOME_LAT
+    // @DisplayName: Backup latitude for home position
+    // @Description:  Backup home latitude position used when not using a positioning system.
+    AP_GROUPINFO("HOME_LAT", 19, ParametersG2, backup_home_lat, 0),
+
+    // @Param: HOME_LON
+    // @DisplayName: Backup longitude for home position
+    // @Description:  Backup home longitude position used when not using a positioning system.
+    AP_GROUPINFO("HOME_LON", 20, ParametersG2, backup_home_lon, 0),
 
     AP_GROUPEND
 };

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -712,11 +712,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: HOME_LAT
     // @DisplayName: Backup latitude for home position
     // @Description:  Backup home latitude position used when not using a positioning system.
+    // @User: Standard
     AP_GROUPINFO("HOME_LAT", 19, ParametersG2, backup_home_lat, 0),
 
     // @Param: HOME_LON
     // @DisplayName: Backup longitude for home position
     // @Description:  Backup home longitude position used when not using a positioning system.
+    // @User: Standard
     AP_GROUPINFO("HOME_LON", 20, ParametersG2, backup_home_lon, 0),
 
     AP_GROUPEND

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -721,6 +721,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("ORIGIN_LON", 20, ParametersG2, backup_origin_lon, 0),
 
+    // @Param: ORIGIN_ALT
+    // @DisplayName: Backup altitude (MSL) for EKF origin
+    // @Description:  Backup EKF origin altitude (MSL) used when not using a positioning system.
+    // @Units: m
+    // @User: Standard
+    AP_GROUPINFO("ORIGIN_ALT", 21, ParametersG2, backup_origin_alt, 0),
+
     AP_GROUPEND
 };
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -709,17 +709,17 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // 18 was scripting
 
-    // @Param: HOME_LAT
-    // @DisplayName: Backup latitude for home position
-    // @Description:  Backup home latitude position used when not using a positioning system.
+    // @Param: ORIGIN_LAT
+    // @DisplayName: Backup latitude for EKF origin
+    // @Description:  Backup EKF origin latitude used when not using a positioning system.
     // @User: Standard
-    AP_GROUPINFO("HOME_LAT", 19, ParametersG2, backup_home_lat, 0),
+    AP_GROUPINFO("ORIGIN_LAT", 19, ParametersG2, backup_origin_lat, 0),
 
-    // @Param: HOME_LON
-    // @DisplayName: Backup longitude for home position
-    // @Description:  Backup home longitude position used when not using a positioning system.
+    // @Param: ORIGIN_LON
+    // @DisplayName: Backup longitude for EKF origin
+    // @Description:  Backup EKF origin longitude used when not using a positioning system.
     // @User: Standard
-    AP_GROUPINFO("HOME_LON", 20, ParametersG2, backup_home_lon, 0),
+    AP_GROUPINFO("ORIGIN_LON", 20, ParametersG2, backup_origin_lon, 0),
 
     AP_GROUPEND
 };

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -366,6 +366,8 @@ public:
     // control over servo output ranges
     SRV_Channels servo_channels;
 
+    AP_Float backup_home_lat;
+    AP_Float backup_home_lon;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -368,6 +368,7 @@ public:
 
     AP_Float backup_origin_lat;
     AP_Float backup_origin_lon;
+    AP_Float backup_origin_alt;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Parameters.h
+++ b/ArduSub/Parameters.h
@@ -366,8 +366,8 @@ public:
     // control over servo output ranges
     SRV_Channels servo_channels;
 
-    AP_Float backup_home_lat;
-    AP_Float backup_home_lon;
+    AP_Float backup_origin_lat;
+    AP_Float backup_origin_lon;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -425,6 +425,7 @@ private:
     void set_home_to_current_location_inflight();
     bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
     bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
+    void set_origin(const Location& loc);
     bool far_from_EKF_origin(const Location& loc);
     void exit_mission();
     bool verify_loiter_unlimited();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -425,7 +425,7 @@ private:
     void set_home_to_current_location_inflight();
     bool set_home_to_current_location(bool lock) WARN_IF_UNUSED;
     bool set_home(const Location& loc, bool lock) WARN_IF_UNUSED;
-    void set_origin(const Location& loc);
+    bool ensure_ekf_origin();
     bool far_from_EKF_origin(const Location& loc);
     void exit_mission();
     bool verify_loiter_unlimited();

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -664,14 +664,14 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.waiting_to_arm_count += 1
 
     def backup_home(self):
-        """Test HOME_LAT and HOME_LON parameters"""
+        """Test ORIGIN_LAT and ORIGIN_LON parameters"""
 
         self.context_push()
         self.set_parameters({
             'GPS_TYPE': 0,              # Disable GPS
             'EK3_SRC1_POSXY': 0,        # Make sure EK3_SRC parameters do not refer to GPS
-            'HOME_LAT': 47.607584,
-            'HOME_LON': -122.343911,
+            'ORIGIN_LAT': 47.607584,
+            'ORIGIN_LON': -122.343911,
         })
         self.reboot_sitl()
         self.context_collect('STATUSTEXT')

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -34,6 +34,22 @@ class Joystick():
     Lateral = 6
 
 
+# Values for EK3_MAG_CAL
+class MagCal():
+    WHEN_FLYING = 0
+    WHEN_MANOEUVRING = 1
+    NEVER = 2
+    AFTER_FIRST_CLIMB = 3
+    ALWAYS = 4
+
+
+# Values for XKMF.S
+class MagFuseSel():
+    NOT_FUSING = 0
+    FUSE_YAW = 1
+    FUSE_MAG = 2
+
+
 class AutoTestSub(vehicle_test_suite.TestSuite):
     @staticmethod
     def get_not_armable_mode_list():
@@ -621,6 +637,115 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self._MAV_CMD_CONDITION_YAW(self.run_cmd)
         self._MAV_CMD_CONDITION_YAW(self.run_cmd_int)
 
+    def wait_ekf_happy_const_pos(self, timeout=45):
+        """Wait for EKF to be happy in constant position mode (no GPS)"""
+
+        # All of these must be set for arming to happen:
+        required_value = (mavutil.mavlink.EKF_ATTITUDE |
+                          mavutil.mavlink.EKF_VELOCITY_HORIZ |
+                          mavutil.mavlink.EKF_VELOCITY_VERT |
+                          mavutil.mavlink.EKF_POS_VERT_ABS |
+                          mavutil.mavlink.EKF_CONST_POS_MODE)
+
+        # None of these bits must be set for arming to happen:
+        error_bits = mavutil.mavlink.EKF_UNINITIALIZED
+
+        self.wait_ekf_flags(required_value, error_bits, timeout=timeout)
+
+    def wait_ready_to_arm_const_pos(self, timeout=120):
+        """Wait for EKF checks to pass in constant position mode (no GPS)"""
+
+        self.progress("Waiting for ready to arm")
+        start = self.get_sim_time()
+        self.wait_ekf_happy_const_pos(timeout=timeout)
+        armable_time = self.get_sim_time() - start
+        self.progress("Took %u seconds to become armable" % armable_time)
+        self.total_waiting_to_arm_time += armable_time
+        self.waiting_to_arm_count += 1
+
+    def backup_home(self):
+        """Test HOME_LAT and HOME_LON parameters"""
+
+        self.context_push()
+        self.set_parameters({
+            'GPS_TYPE': 0,              # Disable GPS
+            'EK3_SRC1_POSXY': 0,        # Make sure EK3_SRC parameters do not refer to GPS
+            'HOME_LAT': 47.607584,
+            'HOME_LON': -122.343911,
+        })
+        self.reboot_sitl()
+        self.context_collect('STATUSTEXT')
+
+        # Wait for the EKF to be happy in constant position mode
+        self.wait_ready_to_arm_const_pos()
+
+        if self.current_onboard_log_contains_message('ORGN'):
+            raise NotAchievedException("Found unexpected ORGN message")
+
+        # This should set the origin and write a record to ORGN
+        self.arm_vehicle()
+
+        self.wait_statustext('Using backup location', check_context=True)
+
+        if not self.current_onboard_log_contains_message('ORGN'):
+            raise NotAchievedException("Did not find expected ORGN message")
+
+        self.disarm_vehicle()
+        self.context_pop()
+
+    def assert_mag_fusion_selection(self, expect_sel):
+        """Get the most recent XKMF message and check the mag fuse selection"""
+        self.progress("Expect mag fusion selection %d" % expect_sel)
+        mlog = self.dfreader_for_current_onboard_log()
+        found_sel = MagFuseSel.NOT_FUSING
+        while True:
+            m = mlog.recv_match(type='XKMF')
+            if m is None:
+                break
+            found_sel = m.S
+            self.progress("Got fusion selection %d" % found_sel)
+        if found_sel != expect_sel:
+            raise NotAchievedException("Expected mag fusion selection %d, found %d" % (expect_sel, found_sel))
+
+    def fuse_mag(self):
+        """Test EK3_MAG_CAL values"""
+        self.context_push()
+
+        # WHEN_FLYING: switch to FUSE_MAG after sub is armed for 5 seconds; switch to FUSE_YAW on disarm
+        self.set_parameters({'EK3_MAG_CAL': MagCal.WHEN_FLYING})
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
+        self.arm_vehicle()
+        self.delay_sim_time(10)
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_MAG)
+        self.disarm_vehicle()
+        self.delay_sim_time(1)
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
+
+        # AFTER_FIRST_CLIMB: switch to FUSE_MAG after sub is armed and descends 2.5m; switch to FUSE_YAW on disarm
+        self.set_parameters({'EK3_MAG_CAL': MagCal.AFTER_FIRST_CLIMB})
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
+        altitude = self.get_altitude(relative=True)
+        self.arm_vehicle()
+        self.set_rc(Joystick.Throttle, 1300)
+        self.wait_altitude(altitude_min=altitude-4, altitude_max=altitude-3, relative=False, timeout=60)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_MAG)
+        self.disarm_vehicle()
+        self.delay_sim_time(1)
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
+
+        # ALWAYS
+        self.set_parameters({'EK3_MAG_CAL': MagCal.ALWAYS})
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.assert_mag_fusion_selection(MagFuseSel.FUSE_MAG)
+
+        self.context_pop()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestSub, self).tests()
@@ -644,6 +769,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.MAV_CMD_MISSION_START,
             self.MAV_CMD_DO_CHANGE_SPEED,
             self.MAV_CMD_CONDITION_YAW,
+            self.backup_home,
+            self.fuse_mag,
         ])
 
         return ret

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1412,6 +1412,9 @@ bool AP_AHRS::set_origin(const Location &loc)
     const bool ret3 = EKF3.setOriginLLH(loc);
 #endif
 
+    // update state so that Log_Write_Home_And_Origin can succeed
+    state.origin_ok = _get_origin(state.origin);
+
     // return success if active EKF's origin was set
     switch (active_EKF_type()) {
 #if AP_AHRS_DCM_ENABLED

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -1067,6 +1067,7 @@ bool CompassCalibrator::fix_radius(void)
 {
     Location loc;
     if (!AP::ahrs().get_location(loc)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Mag(%u) no position, fix_radius skipped", _compass_idx);
         // we don't have a position, leave scale factor as 0. This
         // will disable use of WMM in the EKF. Users can manually set
         // scale factor after calibration if it is known

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -1065,14 +1065,14 @@ bool CompassCalibrator::calculate_orientation(void)
  */
 bool CompassCalibrator::fix_radius(void)
 {
-    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+    Location loc;
+    if (!AP::ahrs().get_location(loc)) {
         // we don't have a position, leave scale factor as 0. This
         // will disable use of WMM in the EKF. Users can manually set
         // scale factor after calibration if it is known
         _params.scale_factor = 0;
         return true;
     }
-    const Location &loc = AP::gps().location();
     float intensity;
     float declination;
     float inclination;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -661,8 +661,6 @@ bool NavEKF3_core::setOrigin(const Location &loc)
     validOrigin = true;
 
     // this section is similar to what is in AP_NavEKF3_Measurements.cpp's NavEKF3_core::readGpsData()
-    Vector3f magNED;
-    getMagNED(magNED);
     if (!stateStruct.quat.is_zero()) {
         alignMagStateDeclination();
         const auto &compass = dal.compass();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -55,9 +55,15 @@ void NavEKF3_core::controlMagYawReset()
     bool finalResetRequest = false;
     bool interimResetRequest = false;
     if (flightResetAllowed && !assume_zero_sideslip()) {
+#if APM_BUILD_TYPE(APM_BUILD_ArduSub)
+        // for sub, we'd like to be far enough away from metal structures like docks and vessels
+        // diving below 2.5m is a reasonable test, so we can use the same constant, but the sign is flipped
+        finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) > EKF3_MAG_FINAL_RESET_ALT;
+#else
         // check that we have reached a height where ground magnetic interference effects are insignificant
         // and can perform a final reset of the yaw and field states
         finalResetRequest = (stateStruct.position.z  - posDownAtTakeoff) < -EKF3_MAG_FINAL_RESET_ALT;
+#endif
 
         // check for increasing height
         bool hgtIncreasing = (posDownAtLastMagReset-stateStruct.position.z) > 0.5f;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -4,6 +4,7 @@
 #include "AP_NavEKF3_core.h"
 
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Logger/AP_Logger.h>
 #include <AP_DAL/AP_DAL.h>
 
 /********************************************************
@@ -422,12 +423,24 @@ void NavEKF3_core::SelectMagFusion()
     if (dataReady) {
         // use the simple method of declination to maintain heading if we cannot use the magnetic field states
         if(inhibitMagStates || magStateResetRequest || !magStateInitComplete) {
+#if HAL_LOGGING_ENABLED
+            if (magFusionSel != MagFuseSel::FUSE_YAW) {
+                magFusionSel = MagFuseSel::FUSE_YAW;
+                WriteMagFusionSelection();
+            }
+#endif
             fuseEulerYaw(yawFusionMethod::MAGNETOMETER);
 
             // zero the test ratio output from the inactive 3-axis magnetometer fusion
             magTestRatio.zero();
 
         } else {
+#if HAL_LOGGING_ENABLED
+            if (magFusionSel != MagFuseSel::FUSE_MAG) {
+                magFusionSel = MagFuseSel::FUSE_MAG;
+                WriteMagFusionSelection();
+            }
+#endif
             // if we are not doing aiding with earth relative observations (eg GPS) then the declination is
             // maintained by fusing declination as a synthesised observation
             // We also fuse declination if we are using the WMM tables
@@ -458,6 +471,20 @@ void NavEKF3_core::SelectMagFusion()
         bodyMagFieldVar.z = P[21][21];
     }
 }
+
+#if HAL_LOGGING_ENABLED
+// log changes to magnetometer fusion selection
+void NavEKF3_core::WriteMagFusionSelection()
+{
+    const struct log_XKMF pkt{
+            LOG_PACKET_HEADER_INIT(LOG_XKMF_MSG),
+            time_us     : AP_HAL::micros64(),
+            core        : core_index,
+            fuse_sel    : static_cast<uint8_t>(magFusionSel)
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+#endif
 
 /*
  * Fuse magnetometer measurements using explicit algebraic equations generated with Matlab symbolic toolbox.

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -441,6 +441,9 @@ void NavEKF3_core::InitialiseVariablesMag()
 #endif
     needMagBodyVarReset = false;
     needEarthBodyVarReset = false;
+#if HAL_LOGGING_ENABLED
+    magFusionSel = MagFuseSel::NOT_FUSING;
+#endif
 }
 
 /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -424,6 +424,15 @@ public:
         // 6 was EXTERNAL_YAW_FALLBACK (do not use)
     };
 
+#if HAL_LOGGING_ENABLED
+    // magnetometer fusion selections
+    enum class MagFuseSel {
+        NOT_FUSING = 0,
+        FUSE_YAW = 1,
+        FUSE_MAG = 2
+    };
+#endif
+
     // are we using (aka fusing) a non-compass yaw?
     bool using_noncompass_for_yaw(void) const;
 
@@ -801,6 +810,11 @@ private:
 
     // determine when to perform fusion of magnetometer measurements
     void SelectMagFusion();
+
+#if HAL_LOGGING_ENABLED
+    // log changes to magnetometer fusion selection
+    void WriteMagFusionSelection();
+#endif
 
     // determine when to perform fusion of true airspeed measurements
     void SelectTasFusion();
@@ -1412,6 +1426,9 @@ private:
     ftype posDownAtLastMagReset;    // vertical position last time the mag states were reset (m)
     ftype yawInnovAtLastMagReset;   // magnetic yaw innovation last time the yaw and mag field states were reset (rad)
     QuaternionF quatAtLastMagReset;  // quaternion states last time the mag states were reset
+#if HAL_LOGGING_ENABLED
+    MagFuseSel magFusionSel;        // magnetometer fusion selection
+#endif
 
     // Used by on ground movement check required when operating on ground without a yaw reference
     ftype gyro_diff;                    // filtered gyro difference (rad/s)

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -15,6 +15,7 @@
     LOG_XKQ_MSG,  \
     LOG_XKT_MSG,  \
     LOG_XKTV_MSG, \
+    LOG_XKMF_MSG, \
     LOG_XKV1_MSG, \
     LOG_XKV2_MSG, \
     LOG_XKY0_MSG, \
@@ -369,6 +370,18 @@ struct PACKED log_XKTV {
     float tvd;
 };
 
+// @LoggerMessage: XKMF
+// @Description: EKF3 Magnetometer Fusion Selection
+// @Field: TimeUS: Time since system startup
+// @Field: C: EKF3 core this data is for
+// @Field: S: Magnetometer fusion selection: 0 not fusing, 1 fuse yaw, 2 fuse mag
+struct PACKED log_XKMF {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint8_t core;
+    uint8_t fuse_sel;
+};
+
 // @LoggerMessage: XKV1
 // @Description: EKF3 State variances (primary core)
 // @Field: TimeUS: Time since system startup
@@ -445,6 +458,8 @@ struct PACKED log_XKV {
       "XKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000", true }, \
     { LOG_XKTV_MSG, sizeof(log_XKTV),                         \
       "XKTV", "QBff", "TimeUS,C,TVS,TVD", "s#rr", "F-00", true }, \
+    { LOG_XKMF_MSG, sizeof(log_XKMF), \
+      "XKMF", "QBB", "TimeUS,C,S", "s#-", "F--", true }, \
     { LOG_XKV1_MSG, sizeof(log_XKV), \
       "XKV1","QBffffffffffff","TimeUS,C,V00,V01,V02,V03,V04,V05,V06,V07,V08,V09,V10,V11", "s#------------", "F-------------" , true }, \
     { LOG_XKV2_MSG, sizeof(log_XKV), \


### PR DESCRIPTION
I'm tossing all of this into a draft PR to make it easy to see what I did.

* fix CI by adding the @User field to the HOME_* parameters
* immediately update the state in AP_AHRS::set_origin. This fixes a subtle bug in GCS_MAVLINK::set_ekf_origin where the call to ahrs.Log_Write_Home_And_Origin doesn't write ORGN records. (I copied the logic from GCS_MAVLINK::set_ekf_origin to Sub::ensure_ekf_origin.) I think I'll pull this out in a separate PR, but I left it here because it allows the autotests to work
* log the mag fusion selection to a new table, XKMF
* Sub::ensure_ekf_origin has all of the logic to use the backup origin
* added autotests